### PR TITLE
fix-post-hook

### DIFF
--- a/crontab
+++ b/crontab
@@ -7,4 +7,4 @@
   --force-renew \
   --agree-tos \
   --non-interactive \
-  --post-hook /usr/sbin/nginx -s reload
+  --post-hook '/usr/sbin/nginx -s reload 2>&1'


### PR DESCRIPTION
## Why

post-hook が certbot コマンドのオプションとして解釈されてしまう

## What

コマンドをクォートで囲う